### PR TITLE
Fix link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A whitepaper style approach to the problem of how a developer might effectively work remotely indefinitely from a sailboat. It is intended to be an open discussion and knowledge pool, with that in mind contributions are eagerly welcomed.
 
-Can be viewed online at [floatingdevs.com](www.floatingdevs.com)
+Can be viewed online at [floatingdevs.com](https://www.floatingdevs.com)
 
 This is currently very early days, entire sections are currently missing and will be filled in as I can get to them.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A whitepaper style approach to the problem of how a developer might effectively work remotely indefinitely from a sailboat. It is intended to be an open discussion and knowledge pool, with that in mind contributions are eagerly welcomed.
 
-Can be viewed online at [floatingdevs.com](https://www.floatingdevs.com)
+Can be viewed online at [floatingdevs.com](https://floatingdevs.com)
 
 This is currently very early days, entire sections are currently missing and will be filled in as I can get to them.
 
@@ -13,4 +13,3 @@ To contribute to devs-on-a-boat, fork this repository and clone it to your local
 You can use a variety of markdown editors to work on this content. Some of the more popular extensions for Visual Studio Code are [listed here](https://code.visualstudio.com/docs/languages/markdown). However, even without an extension, you can press Ctrl-Shift-V to preview changes to a markdown file within VS Code.
 
 This website uses [Jekyll](https://jekyllrb.com/) to build the website, along with the [just-the-docs theme](https://pmarsceill.github.io/just-the-docs/) which incidently contains the documentation on how to use this theme!
-


### PR DESCRIPTION
Without the protocol, the link takes you to https://github.com/cyclingwithelephants/devs-on-a-boat/blob/main/www.floatingdevs.com